### PR TITLE
Do not include tableau in state

### DIFF
--- a/include/CResult.h
+++ b/include/CResult.h
@@ -16,7 +16,6 @@ public:
 
 	explicit CResult( const CTableauState& aInitialTableauState );
 
-	const history& GetHistory() const;
 	const CTableauState& GetTableauState() const;
 	const std::atomic_ulong& GetCounter() const;
 
@@ -24,10 +23,7 @@ public:
 
 	bool IsBetterResult( const history::size_type& aCountHits, const unsigned short& aScore ) const;
 
-	void SaveHistory( std::string_view aOutputFileName, const CTableau& aInitialTableau ) const;
-
 private:
-	history mHistory;
 	CTableauState mTableauState;
 	std::mutex mMutex;
 	std::atomic_ulong mCounter;

--- a/include/CResult.h
+++ b/include/CResult.h
@@ -20,7 +20,7 @@ public:
 	const CTableauState& GetTableauState() const;
 	const std::atomic_ulong& GetCounter() const;
 
-	void FindBest( const unsigned int& aNTries, std::mt19937_64& aRNG, const bool aSpeed );
+	void FindBest( const unsigned int& aNTries, const CTableau& aTableau, std::mt19937_64& aRNG, const bool aSpeed );
 
 	bool IsBetterResult( const history::size_type& aCountHits, const unsigned short& aScore ) const;
 

--- a/include/CTableau.h
+++ b/include/CTableau.h
@@ -37,8 +37,6 @@ public:
 
 	const index& GetRows() const;
 
-	void HitPiece( const index& aRowIndex, const index& aColIndex );
-
 	bool IsInside( const index& aRowIndex, const index& aColIndex ) const;
 
 	index CountPieces() const;

--- a/include/CTableauState.h
+++ b/include/CTableauState.h
@@ -51,35 +51,36 @@ public:
 	using coordinates = std::pair<CTableau::index, CTableau::index>;
 	using coordinates_vector = std::vector<coordinates>;
 	using piece_type = CTableau::piece_type;
+	using history = std::vector<coordinates>;
 
-	explicit CTableauState( const CTableau& aTableau, const std::optional<coordinates>& aCurrentPosition );
+	explicit CTableauState( const std::optional<coordinates>& aCurrentPosition );
 
-	const CTableau& GetTableau() const;
+	const history& GetHistory() const;
 	const std::optional<coordinates>& GetCurrentPosition() const;
 	const unsigned short& GetScore() const;
 
 	// Updates set and multi states with the piece hit. Returrns score for hitting such piece
 	unsigned short Update( const piece_type& aPiece );
 
-	const coordinates& SetCurrentPositionAtRandom( std::mt19937_64& aRNG );
+	const coordinates& SetCurrentPositionAtRandom( const CTableau& aTableau, std::mt19937_64& aRNG );
 
-	std::optional<coordinates> Move( std::mt19937_64& aRNG );
+	std::optional<coordinates> Move( const CTableau& aTableau, std::mt19937_64& aRNG );
 
 private:
-	void MoveDiagonal( coordinates_vector& aDestinations ) const;
-	void MoveDiagonal( coordinates_vector& aDestinations, int aSteps ) const;
-	void MoveStraight( coordinates_vector& aDestinations ) const;
-	void MoveStraight( coordinates_vector& aDestinations, int aSteps ) const;
-	void MoveKnight( coordinates_vector& aDestinations ) const;
-	void MoveWildcard( coordinates_vector& aDestinations ) const;
+	void MoveDiagonal( const CTableau& aTableau, coordinates_vector& aDestinations ) const;
+	void MoveDiagonal( const CTableau& aTableau, coordinates_vector& aDestinations, int aSteps ) const;
+	void MoveStraight( const CTableau& aTableau, coordinates_vector& aDestinations ) const;
+	void MoveStraight( const CTableau& aTableau, coordinates_vector& aDestinations, int aSteps ) const;
+	void MoveKnight( const CTableau& aTableau, coordinates_vector& aDestinations ) const;
+	void MoveWildcard( const CTableau& aTableau, coordinates_vector& aDestinations ) const;
 
-	void AppendDestination( coordinates_vector& aDestinations, const coordinates& aDestination ) const;
+	void AppendDestination( const CTableau& aTableau, coordinates_vector& aDestinations, const coordinates& aDestination ) const;
 
 	static constexpr unsigned short NUMERIC_DESTINATIONS_COUNT();
 	static constexpr unsigned short KQ_DESTINATIONS_COUNT();
 	static constexpr unsigned short RB_DESTINATIONS_COUNT();
 
-	CTableau mTableau;
+	history mHistory;
 	std::optional<coordinates> mCurrentPosition;
 	CSetState mSetState;
 	CMultiState mMultiState;

--- a/include/CTableauState.h
+++ b/include/CTableauState.h
@@ -66,6 +66,8 @@ public:
 
 	std::optional<coordinates> Move( const CTableau& aTableau, std::mt19937_64& aRNG );
 
+	void SaveHistory( std::string_view aOutputFileName, const CTableau& aTableau ) const;
+
 private:
 	void MoveDiagonal( const CTableau& aTableau, coordinates_vector& aDestinations ) const;
 	void MoveDiagonal( const CTableau& aTableau, coordinates_vector& aDestinations, int aSteps ) const;

--- a/src/CResult.cpp
+++ b/src/CResult.cpp
@@ -11,11 +11,6 @@ CResult::CResult( const CTableauState& aInitialTableauState ) :
 {
 }
 
-const CResult::history& CResult::GetHistory() const
-{
-	return mHistory;
-}
-
 const CTableauState& CResult::GetTableauState() const
 {
 	return mTableauState;
@@ -29,7 +24,7 @@ void CResult::FindBest( const unsigned int& aNTries, const CTableau& aTableau, s
 {
 	const auto initialTableauState = mTableauState;
 	const auto& targetPieces = aTableau.CountPieces() + ( aSpeed ? 0 : 1 );
-	for( ; mCounter < aNTries && mHistory.size() < targetPieces; mCounter++ ) // Iterate many times
+	for( ; mCounter < aNTries && mTableauState.GetHistory().size() < targetPieces; mCounter++ ) // Iterate many times
 	{
 		auto tableauState = initialTableauState;
 		history posHistory{ initialTableauState.GetCurrentPosition().value_or( tableauState.SetCurrentPositionAtRandom( aTableau, aRNG ) ) };
@@ -37,38 +32,13 @@ void CResult::FindBest( const unsigned int& aNTries, const CTableau& aTableau, s
 			posHistory.emplace_back( *nextPosition );
 		std::lock_guard lock( mMutex );
 		if( IsBetterResult( posHistory.size(), tableauState.GetScore() ) ) // New record!
-		{
-			mHistory = std::move( posHistory );
 			mTableauState = std::move( tableauState );
-		}
 	}
 }
 
 bool CResult::IsBetterResult( const history::size_type& aCountHits, const unsigned short& aScore ) const
 {
-	return ( aCountHits > mHistory.size() ) || ( aCountHits == mHistory.size() && aScore > mTableauState.GetScore() );
+	return ( aCountHits > mTableauState.GetHistory().size() ) || ( aCountHits == mTableauState.GetHistory().size() && aScore > mTableauState.GetScore() );
 }
-
-void CResult::SaveHistory( std::string_view aOutputFileName, const CTableau& aInitialTableau ) const
-{
-	std::ofstream outfile;
-	outfile.open( aOutputFileName.data() );
-	outfile << "Step #   (i,j)   Piece" << std::endl;
-	outfile << "----------------------" << std::endl;
-
-	unsigned int index = 0;
-	for( const auto& epoch : mHistory )
-		outfile << std::setw( 4 ) << index++ << "     (" << epoch.first << "," << epoch.second << ")     " << std::setw( 1 ) << CTableau::PieceToString( aInitialTableau.GetPiece( epoch.first, epoch.second ) ) << std::endl;
-	// Write also remaining pieces
-	outfile << "----------------------" << std::endl;
-	outfile << "   Remaining Pieces   " << std::endl;
-	outfile << "----------------------" << std::endl;
-	for( CTableau::index i = 0; i < aInitialTableau.GetRows(); i++ )
-		for( CTableau::index j = 0; j < aInitialTableau.GetRows(); j++ )
-			if( aInitialTableau.GetPiece( i, j ) != CTableau::E_PIECE_TYPE::EMPTY && std::find( mTableauState.GetHistory().cbegin(), mTableauState.GetHistory().cend(), std::make_pair( i, j ) ) == mTableauState.GetHistory().cend() )
-				outfile << "(" << i << "," << j << "): " << CTableau::PieceToString( aInitialTableau.GetPiece( i, j ) ) << std::endl;
-	outfile.close();
-}
-
 
 };

--- a/src/CTableau.cpp
+++ b/src/CTableau.cpp
@@ -53,11 +53,6 @@ const CTableau::index& CTableau::GetRows() const
 	return mRows;
 }
 
-void CTableau::HitPiece( const index& aRowIndex, const index& aColIndex )
-{
-	mPieces[ aRowIndex * mRows + aColIndex ] = E_PIECE_TYPE::EMPTY;
-}
-
 bool CTableau::IsInside( const index& aRowIndex, const index& aColIndex ) const
 {
 	return aRowIndex < mRows && aColIndex < mRows;

--- a/src/CTableauState.cpp
+++ b/src/CTableauState.cpp
@@ -1,5 +1,7 @@
 #include "CTableauState.h"
 
+#include <fstream>
+#include <iomanip>
 #include <set>
 
 namespace blacksmith
@@ -170,6 +172,27 @@ std::optional<CTableauState::coordinates> CTableauState::Move( const CTableau& a
 		mCurrentPosition.reset();
 
 	return mCurrentPosition;
+}
+
+void CTableauState::SaveHistory( std::string_view aOutputFileName, const CTableau& aInitialTableau ) const
+{
+	std::ofstream outfile;
+	outfile.open( aOutputFileName.data() );
+	outfile << "Step #   (i,j)   Piece" << std::endl;
+	outfile << "----------------------" << std::endl;
+
+	unsigned int index = 0;
+	for( const auto& epoch : mHistory )
+		outfile << std::setw( 4 ) << index++ << "     (" << epoch.first << "," << epoch.second << ")     " << std::setw( 1 ) << CTableau::PieceToString( aInitialTableau.GetPiece( epoch.first, epoch.second ) ) << std::endl;
+	// Write also remaining pieces
+	outfile << "----------------------" << std::endl;
+	outfile << "   Remaining Pieces   " << std::endl;
+	outfile << "----------------------" << std::endl;
+	for( CTableau::index i = 0; i < aInitialTableau.GetRows(); i++ )
+		for( CTableau::index j = 0; j < aInitialTableau.GetRows(); j++ )
+			if( aInitialTableau.GetPiece( i, j ) != CTableau::E_PIECE_TYPE::EMPTY && std::find( mHistory.cbegin(), mHistory.cend(), std::make_pair( i, j ) ) == mHistory.cend() )
+				outfile << "(" << i << "," << j << "): " << CTableau::PieceToString( aInitialTableau.GetPiece( i, j ) ) << std::endl;
+	outfile.close();
 }
 
 void CTableauState::MoveDiagonal( const CTableau& aTableau, coordinates_vector& aDestinations ) const

--- a/src/CTableauState.cpp
+++ b/src/CTableauState.cpp
@@ -94,15 +94,14 @@ void CTableauState::CMultiState::Reset()
 	*this = CMultiState();
 }
 
-CTableauState::CTableauState( const CTableau& aTableau, const std::optional<coordinates>& aCurrentPosition ) :
-	mTableau( aTableau ),
+CTableauState::CTableauState( const std::optional<coordinates>& aCurrentPosition ) :
 	mCurrentPosition( aCurrentPosition )
 {
 }
 
-const CTableau& CTableauState::GetTableau() const
+const CTableauState::history& CTableauState::GetHistory() const
 {
-	return mTableau;
+	return mHistory;
 }
 
 const std::optional<CTableauState::coordinates>& CTableauState::GetCurrentPosition() const
@@ -115,56 +114,56 @@ const unsigned short& CTableauState::GetScore() const
 	return mScore;
 }
 
-const CTableauState::coordinates& CTableauState::SetCurrentPositionAtRandom( std::mt19937_64& aRNG )
+const CTableauState::coordinates& CTableauState::SetCurrentPositionAtRandom( const CTableau& aTableau, std::mt19937_64& aRNG )
 {
 	coordinates_vector dests; // Save all possible aDestinations
-	dests.reserve( mTableau.Size() );
-	MoveWildcard( dests );
+	dests.reserve( aTableau.Size() );
+	MoveWildcard( aTableau, dests );
 	if( !dests.empty() ) // If it's possible
 		mCurrentPosition = dests[ aRNG() % dests.size() ];
 
 	return *mCurrentPosition;
 }
 
-std::optional<CTableauState::coordinates> CTableauState::Move( std::mt19937_64& aRNG )
+std::optional<CTableauState::coordinates> CTableauState::Move( const CTableau& aTableau, std::mt19937_64& aRNG )
 {
 	coordinates_vector destinations; // Save all possible aDestinations
-	if( !mCurrentPosition || mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::EMPTY )		  // Empty
+	if( !mCurrentPosition || aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::EMPTY )		  // Empty
 		return {};
-	else if( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::QUEEN )		  // Queen
+	else if( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::QUEEN )		  // Queen
 	{
 		destinations.reserve( KQ_DESTINATIONS_COUNT() );
-		MoveDiagonal( destinations );
-		MoveStraight( destinations );
+		MoveDiagonal( aTableau, destinations );
+		MoveStraight( aTableau, destinations );
 	}
-	else if( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::BISHOP ) // Bishop
+	else if( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::BISHOP ) // Bishop
 	{
 		destinations.reserve( RB_DESTINATIONS_COUNT() );
-		MoveDiagonal( destinations );
+		MoveDiagonal( aTableau, destinations );
 	}
-	else if( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::ROOK ) // Rook
+	else if( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::ROOK ) // Rook
 	{
 		destinations.reserve( RB_DESTINATIONS_COUNT() );
-		MoveStraight( destinations );
+		MoveStraight( aTableau, destinations );
 	}
-	else if( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::KNIGHT ) // Knight
+	else if( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::KNIGHT ) // Knight
 	{
 		destinations.reserve( KQ_DESTINATIONS_COUNT() );
-		MoveKnight( destinations );
+		MoveKnight( aTableau, destinations );
 	}
-	else if( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::WILDCARD ) // Rum (WILDCARD!)
+	else if( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) == CTableau::E_PIECE_TYPE::WILDCARD ) // Rum (WILDCARD!)
 	{
-		destinations.reserve( mTableau.Size() );
-		MoveWildcard( destinations );
+		destinations.reserve( aTableau.Size() );
+		MoveWildcard( aTableau, destinations );
 	}
 	else
 	{
 		destinations.reserve( NUMERIC_DESTINATIONS_COUNT() );
-		MoveDiagonal( destinations, static_cast< int >( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) ) );
-		MoveStraight( destinations, static_cast< int >( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) ) );
+		MoveDiagonal( aTableau, destinations, static_cast< int >( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) ) );
+		MoveStraight( aTableau, destinations, static_cast< int >( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) ) );
 	}
-	mScore += Update( mTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) );
-	mTableau.HitPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second );
+	mScore += Update( aTableau.GetPiece( ( *mCurrentPosition ).first, ( *mCurrentPosition ).second ) );
+	mHistory.push_back( std::move( *mCurrentPosition ) );
 	if( !destinations.empty() ) // If it's possible
 		mCurrentPosition = destinations[ aRNG() % destinations.size() ];
 	else
@@ -173,65 +172,66 @@ std::optional<CTableauState::coordinates> CTableauState::Move( std::mt19937_64& 
 	return mCurrentPosition;
 }
 
-void CTableauState::MoveDiagonal( coordinates_vector& aDestinations ) const
+void CTableauState::MoveDiagonal( const CTableau& aTableau, coordinates_vector& aDestinations ) const
 {
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - std::min( ( *mCurrentPosition ).first - 0, ( *mCurrentPosition ).second - 0 ),
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - std::min( ( *mCurrentPosition ).first - 0, ( *mCurrentPosition ).second - 0 ),
 		( *mCurrentPosition ).second - std::min( ( *mCurrentPosition ).first - 0, ( *mCurrentPosition ).second - 0 ) } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + std::min( 5 - ( *mCurrentPosition ).first, ( *mCurrentPosition ).second - 0 ),
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + std::min( 5 - ( *mCurrentPosition ).first, ( *mCurrentPosition ).second - 0 ),
 		( *mCurrentPosition ).second - std::min( 5 - ( *mCurrentPosition ).first, ( *mCurrentPosition ).second - 0 ) } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + std::min( 5 - ( *mCurrentPosition ).first, 5 - ( *mCurrentPosition ).second ),
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + std::min( 5 - ( *mCurrentPosition ).first, 5 - ( *mCurrentPosition ).second ),
 		( *mCurrentPosition ).second + std::min( 5 - ( *mCurrentPosition ).first, 5 - ( *mCurrentPosition ).second ) } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - std::min( ( *mCurrentPosition ).first - 0, 5 - ( *mCurrentPosition ).second ),
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - std::min( ( *mCurrentPosition ).first - 0, 5 - ( *mCurrentPosition ).second ),
 		( *mCurrentPosition ).second + std::min( ( *mCurrentPosition ).first - 0, 5 - ( *mCurrentPosition ).second ) } );
 }
 
-void CTableauState::MoveDiagonal( coordinates_vector& aDestinations, int aSteps ) const
+void CTableauState::MoveDiagonal( const CTableau& aTableau, coordinates_vector& aDestinations, int aSteps ) const
 {
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - aSteps, ( *mCurrentPosition ).second - aSteps } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + aSteps, ( *mCurrentPosition ).second - aSteps } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + aSteps, ( *mCurrentPosition ).second + aSteps } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - aSteps, ( *mCurrentPosition ).second + aSteps } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - aSteps, ( *mCurrentPosition ).second - aSteps } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + aSteps, ( *mCurrentPosition ).second - aSteps } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + aSteps, ( *mCurrentPosition ).second + aSteps } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - aSteps, ( *mCurrentPosition ).second + aSteps } );
 }
 
-void CTableauState::MoveStraight( coordinates_vector& aDestinations ) const
+void CTableauState::MoveStraight( const CTableau& aTableau, coordinates_vector& aDestinations ) const
 {
-	AppendDestination( aDestinations, { 0, ( *mCurrentPosition ).second } );
-	AppendDestination( aDestinations, { 5, ( *mCurrentPosition ).second } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first, 0 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first, 5 } );
+	AppendDestination( aTableau, aDestinations, { 0, ( *mCurrentPosition ).second } );
+	AppendDestination( aTableau, aDestinations, { 5, ( *mCurrentPosition ).second } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first, 0 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first, 5 } );
 }
 
-void CTableauState::MoveStraight( coordinates_vector& aDestinations, int aSteps ) const
+void CTableauState::MoveStraight( const CTableau& aTableau, coordinates_vector& aDestinations, int aSteps ) const
 {
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + aSteps, ( *mCurrentPosition ).second } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - aSteps, ( *mCurrentPosition ).second } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first, ( *mCurrentPosition ).second + aSteps } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first, ( *mCurrentPosition ).second - aSteps } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + aSteps, ( *mCurrentPosition ).second } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - aSteps, ( *mCurrentPosition ).second } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first, ( *mCurrentPosition ).second + aSteps } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first, ( *mCurrentPosition ).second - aSteps } );
 }
 
-void CTableauState::MoveKnight( coordinates_vector& aDestinations ) const
+void CTableauState::MoveKnight( const CTableau& aTableau, coordinates_vector& aDestinations ) const
 {
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - 1, ( *mCurrentPosition ).second - 2 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - 1, ( *mCurrentPosition ).second + 2 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + 1, ( *mCurrentPosition ).second - 2 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + 1, ( *mCurrentPosition ).second + 2 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - 2, ( *mCurrentPosition ).second - 1 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first - 2, ( *mCurrentPosition ).second + 1 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + 2, ( *mCurrentPosition ).second - 1 } );
-	AppendDestination( aDestinations, { ( *mCurrentPosition ).first + 2, ( *mCurrentPosition ).second + 1 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - 1, ( *mCurrentPosition ).second - 2 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - 1, ( *mCurrentPosition ).second + 2 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + 1, ( *mCurrentPosition ).second - 2 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + 1, ( *mCurrentPosition ).second + 2 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - 2, ( *mCurrentPosition ).second - 1 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first - 2, ( *mCurrentPosition ).second + 1 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + 2, ( *mCurrentPosition ).second - 1 } );
+	AppendDestination( aTableau, aDestinations, { ( *mCurrentPosition ).first + 2, ( *mCurrentPosition ).second + 1 } );
 }
 
-void CTableauState::MoveWildcard( coordinates_vector& aDestinations ) const
+void CTableauState::MoveWildcard( const CTableau& aTableau, coordinates_vector& aDestinations ) const
 {
-	for( CTableau::index i = 0; i < mTableau.GetRows(); i++ )
-		for( CTableau::index j = 0; j < mTableau.GetRows(); j++ )
-			AppendDestination( aDestinations, { i, j } );
+	for( CTableau::index i = 0; i < aTableau.GetRows(); i++ )
+		for( CTableau::index j = 0; j < aTableau.GetRows(); j++ )
+			AppendDestination( aTableau, aDestinations, { i, j } );
 	return;
 }
 
-void CTableauState::AppendDestination( coordinates_vector& aDestinations, const coordinates& aDestination ) const
+void CTableauState::AppendDestination( const CTableau& aTableau, coordinates_vector& aDestinations, const coordinates& aDestination ) const
 {
-	if( *mCurrentPosition != aDestination && mTableau.IsInside( aDestination.first, aDestination.second ) && mTableau.GetPiece( aDestination.first, aDestination.second ) != CTableau::E_PIECE_TYPE::EMPTY )
+	if( *mCurrentPosition != aDestination && aTableau.IsInside( aDestination.first, aDestination.second ) && aTableau.GetPiece( aDestination.first, aDestination.second ) != CTableau::E_PIECE_TYPE::EMPTY &&
+		std::find( mHistory.cbegin(), mHistory.cend(), aDestination ) == mHistory.cend() )
 		aDestinations.push_back( aDestination );
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,8 +14,8 @@ int main( const int aArgsCount, const char** aArgs )
 	std::mt19937_64 RNG{ inputArgs.mSeed };
 	const CTableau initialBoard( inputArgs.mBoardFileName );
 
-	CResult bestResult{ CTableauState{ initialBoard, inputArgs.mInitialCoordinates } };
-	std::async( &CResult::FindBest, &bestResult, inputArgs.mMaxSteps, std::ref( RNG ), inputArgs.mSpeed ).wait();
+	CResult bestResult{ CTableauState{ inputArgs.mInitialCoordinates } };
+	std::async( &CResult::FindBest, &bestResult, inputArgs.mMaxSteps, initialBoard, std::ref( RNG ), inputArgs.mSpeed ).wait();
 	bestResult.SaveHistory( inputArgs.mBestPatternFileName, initialBoard );
 
 	return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ int main( const int aArgsCount, const char** aArgs )
 
 	CResult bestResult{ CTableauState{ inputArgs.mInitialCoordinates } };
 	std::async( &CResult::FindBest, &bestResult, inputArgs.mMaxSteps, initialBoard, std::ref( RNG ), inputArgs.mSpeed ).wait();
-	bestResult.SaveHistory( inputArgs.mBestPatternFileName, initialBoard );
+	bestResult.GetTableauState().SaveHistory( inputArgs.mBestPatternFileName, initialBoard );
 
 	return 0;
 }


### PR DESCRIPTION
Stops saving the tableau as a member of the state to avoid unnecesary copies of it.

Improves performance